### PR TITLE
Added plugin to hack Danish month names

### DIFF
--- a/_plugins/localize_dates.rb
+++ b/_plugins/localize_dates.rb
@@ -1,0 +1,18 @@
+require 'date'
+
+MONTH_NAMES = %w(januar februar marts april maj juni juli august september oktober november cecember)
+
+module Jekyll
+  module LocalizeDates
+    def date(time, format)
+      if format == "%B %-d, %Y"
+        # Hack to correct naming of months and format for the remote-theme
+        "#{time.strftime("%-d")}. #{MONTH_NAMES[time.month-1]} #{time.strftime("%Y")}"
+      else
+        time.strftime(format)
+      end
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::LocalizeDates)


### PR DESCRIPTION
The original theme (mmistakes/minimal-mistakes) uses `"%B %-d, %Y"` to show the updated at date. This is not the convention in Danish, where we usually want `"%-d. %B %Y"` instead, however, Jekyll doesn't (yet) support translations of month names, so this plugin will look up the month name and do the formatting manually, when fed with the `"%B %-d, %Y"` pattern.